### PR TITLE
Pulling latest code from monitoring branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
   logstash:
     container_name: logstash
     image: logstash
+    ports:
+      - 12201:12201
+      - 12201:12201/udp
     expose:
       - 5044
       - 12201/udp

--- a/logstash/config/30-generic-filters.conf
+++ b/logstash/config/30-generic-filters.conf
@@ -1,4 +1,4 @@
-lfilter {
+filter {
 
   if [type] == "alert" {
     mutate {
@@ -58,8 +58,5 @@ lfilter {
   mutate {
     uppercase => ["log_level"]
   }
-  
-  json {
-    source => "message"
-  }
 }
+

--- a/logstash/config/30-generic-filters.conf
+++ b/logstash/config/30-generic-filters.conf
@@ -1,4 +1,4 @@
-filter {
+lfilter {
 
   if [type] == "alert" {
     mutate {
@@ -58,5 +58,8 @@ filter {
   mutate {
     uppercase => ["log_level"]
   }
-
+  
+  json {
+    source => "message"
+  }
 }

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -24,24 +24,41 @@ scrape_configs:
     scrape_interval: 10s
     scrape_timeout: 5s
     static_configs:
-      - targets: ['nodeexporter:9100']
-        labels: {'host': 'Eisbach'}
+      - targets: ['52.37.91.86:9100']
+        labels: {'group': 'production'}
 
   - job_name: 'containers'
+    scrape_interval: 5s
+    scrape_timeout: 4s
+    static_configs:
+      - targets: ['52.37.91.86:8080']
+        labels:
+          group: 'production'
+
+  - job_name: 'node_development'
     scrape_interval: 10s
     scrape_timeout: 5s
     static_configs:
-      - targets: ['cadvisor:8080']
-        labels: {'host': 'Eisbach'}
+      - targets: ['54.71.126.189:9100']
+        labels: {'group': 'development'}
+
+  - job_name: 'containers_development'
+    scrape_interval: 5s
+    scrape_timeout: 4s
+    static_configs:
+      - targets: ['54.71.126.189:8080']
+        labels:
+          group: 'development'
+
 
   #Will/23.08.16: dcom restart prometheus suffices to load config/rule changes
 
-  - job_name: 'prometheus-server'
-    scrape_interval: 10s
-    scrape_timeout: 5s
-    static_configs:
-      - targets: ['localhost:9090']
-        labels: {'host': 'Eisbach'}
+#  - job_name: 'prometheus-server'
+#    scrape_interval: 10s
+#    scrape_timeout: 5s
+#    static_configs:
+#      - targets: ['localhost:9090']
+#        labels: {'host': 'Eisbach'}
 
   # - job_name: 'couchdb'
   #   scrape_interval: 10s


### PR DESCRIPTION
Currently ElasticSearch, logstash versions have changed and since we did not have any tags, it pulled latest and monitoring failed.
We need to synch with latest so that we also get the latest fixes.