### PR TITLE
Fixing yaml syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   # Takes care of piling piling up Elasticsearch indices/logs. Can do many other things as well.
   # Set up a cron or Jenkins job that runs "docker-compose run --rm curator --config /config.yml /action-file.yml" every once in a while.
-curator:
+  curator:
     image: bobrik/curator
     volumes:
       - ./curator/action-file.yml:/action-file.yml


### PR DESCRIPTION
Curator container should be under Services group I believe, but it wasn't for some reason. Resulting this error:
```
ERROR: yaml.parser.ParserError: while parsing a block mapping
  in "./docker-compose.yml", line 1, column 1
expected <block end>, but found '<block mapping start>'
  in "./docker-compose.yml", line 101, column 3
```