### PR TITLE
Fix for letsencrypt companian. Name of image was changed from docker-…

### DIFF
--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 #########################################################
 
   nginx-letsencrypt:
-    image: jrcs/docker-letsencrypt-nginx-proxy-companion
+    image: jrcs/letsencrypt-nginx-proxy-companion
     restart: always
     volumes_from:
       - nginx-proxy


### PR DESCRIPTION
…letsencrypt-nginx-proxy-companion to letsencrypt-nginx-proxy-companion