### PR TITLE
Switch docker config to the new non-RFC1918 IP adresses (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For debugging: In case you would like certain containers to log to `stdout`becau
 #    logging:
 #      driver: gelf
 #      options:
-#        gelf-address: udp://192.16.0.38:12201
+#        gelf-address: udp://172.16.0.38:12201
 #        labels: container_group
 ```
 

--- a/logging/docker-compose.yml
+++ b/logging/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -42,7 +42,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
     command: logstash -f /config
 
@@ -71,7 +71,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
     environment:
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
@@ -90,7 +90,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.15.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -108,7 +108,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
     environment:
       - NODE_OPTIONS=--max-old-space-size=200 # fixes memory leak (https://github.com/elastic/kibana/issues/5170)
@@ -130,7 +130,7 @@ services:
   #   # logging:
   #   #   driver: gelf
   #   #   options:
-  #   #     gelf-address: udp://192.16.0.38:12201
+  #   #     gelf-address: udp://172.16.0.38:12201
   #   #     labels: container_group
 
 #########################################################
@@ -169,5 +169,3 @@ networks:
   #       labels: container_group
   #   environment:
   #     - API_KEY=
-
-

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -39,7 +39,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -69,7 +69,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -87,7 +87,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
     environment:
       - GF_SECURITY_ADMIN_USER=admin
@@ -111,7 +111,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -188,5 +188,3 @@ networks:
   #       labels: container_group
   #   environment:
   #     - API_KEY=
-
-

--- a/node/node.docker-compose.yml
+++ b/node/node.docker-compose.yml
@@ -17,7 +17,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -35,7 +35,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 #########################################################
@@ -56,7 +56,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: udp://192.16.0.38:12201
+        gelf-address: udp://172.16.0.38:12201
         labels: container_group
 
 networks:

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     # logging:
     #   driver: gelf
     #   options:
-    #     gelf-address: udp://192.15.0.38:12201
+    #     gelf-address: udp://172.16.0.38:12201
     #     labels: container_group
 
 #########################################################
@@ -46,7 +46,7 @@ services:
     # logging:
     #   driver: gelf
     #   options:
-    #     gelf-address: udp://192.15.0.38:12201
+    #     gelf-address: udp://172.16.0.38:12201
     #     labels: container_group
 
 #########################################################
@@ -66,7 +66,7 @@ services:
     # logging:
     #   driver: gelf
     #   options:
-    #     gelf-address: udp://192.15.0.38:12201
+    #     gelf-address: udp://172.16.0.38:12201
     #     labels: container_group
     environment:
       - DEBUG=false


### PR DESCRIPTION
Changed all gelf-configurations to the new non-RFC1918 IPs 